### PR TITLE
set max dependency version to next major version, to avoid broken build

### DIFF
--- a/rapid.cabal
+++ b/rapid.cabal
@@ -43,11 +43,11 @@ source-repository head
 
 library
     build-depends:
-        async >= 2.1 && < 2.3,
-        base >= 4.8 && < 4.20,
-        containers >= 0.5 && < 0.8,
+        async >= 2.1 && < 3,
+        base >= 4.8 && < 5,
+        containers >= 0.5 && < 1,
         foreign-store == 0.2.*,
-        stm >= 2.4 && < 2.7
+        stm >= 2.4 && < 3
     default-language: Haskell2010
     ghc-options: -W
     exposed-modules:


### PR DESCRIPTION
Hello, 
The package is marked broken on Nix, cause the max dependency version for the `base` lib, was too low.
I increased the max dependency version to the next major version, to avoid broken build for minor version upgrades, but also to avoid breaking changes.
Greetings Micha :) 